### PR TITLE
Create eleventy-plugin-mastodon-share.json

### DIFF
--- a/src/_data/plugins/eleventy-plugin-mastodon-share.json
+++ b/src/_data/plugins/eleventy-plugin-mastodon-share.json
@@ -1,5 +1,5 @@
 {
   "npm": "@kylereddoch/eleventy-plugin-mastodon-share",
   "author": "kylereddoch",
-  "description": "Mastodon sharing for Eleventy with an instance picker, popular instances, and saved preferred server support."
+  "description": "Mastodon sharing plugin for Eleventy with an instance picker, popular instances, and saved preferred server support."
 }

--- a/src/_data/plugins/eleventy-plugin-mastodon-share.json
+++ b/src/_data/plugins/eleventy-plugin-mastodon-share.json
@@ -1,0 +1,5 @@
+{
+  "npm": "@kylereddoch/eleventy-plugin-mastodon-share",
+  "author": "kylereddoch",
+  "description": "Mastodon sharing for Eleventy with an instance picker, popular instances, and saved preferred server support."
+}

--- a/src/_data/starters/11ty-starter-submission.json
+++ b/src/_data/starters/11ty-starter-submission.json
@@ -1,0 +1,7 @@
+{
+  "url": "https://github.com/kylereddoch/retro-garden-eleventy-theme",
+  "name": "Retro Garden",
+  "description": "An open source Eleventy theme that blends IndieWeb publishing habits with playful early-web personality.",
+  "author": "kylereddoch",
+  "demo": "https://retro-garden-eleventy-theme.vercel.app/"
+}


### PR DESCRIPTION
## Summary

Adds `@kylereddoch/eleventy-plugin-mastodon-share` to the Eleventy community plugin directory.

## Plugin JSON

```json
{
  "npm": "@kylereddoch/eleventy-plugin-mastodon-share",
  "author": "kylereddoch",
  "description": "Mastodon sharing for Eleventy with an instance picker, popular instances, and saved preferred server support."
}
```

## Notes

- npm package: `@kylereddoch/eleventy-plugin-mastodon-share`
- repository: `https://github.com/kylereddoch/eleventy-plugin-mastodon-share`