### PR TITLE
Don't suggest parsing YAML by returning {}

### DIFF
--- a/src/docs/data-custom.md
+++ b/src/docs/data-custom.md
@@ -22,7 +22,7 @@ Note that you can also add [Custom Front Matter Formats](/docs/data-frontmatter-
 {% set codeContent %}
 export default function (eleventyConfig) {
 	// Receives file contents, return parsed data
-	eleventyConfig.addDataExtension("yml,yaml", (contents, filePath) => {
+	eleventyConfig.addDataExtension("fileExtension", (contents, filePath) => {
 		return {};
 	});
 };


### PR DESCRIPTION
My friend was following these docs to add YAML support and copied the first snippet that said "yml" and was very confused about why no data was coming out.