### PR TITLE
Add eleventy-plugin-rangefind to community plugins

### DIFF
--- a/src/_data/plugins/eleventy-plugin-rangefind.json
+++ b/src/_data/plugins/eleventy-plugin-rangefind.json
@@ -1,0 +1,5 @@
+{
+	"npm": "eleventy-plugin-rangefind",
+	"author": "xjodoin",
+	"description": "adds serverless full-text search: indexes the built site into a static rangefind index (BM25F relevance, typo correction, autocomplete) that the browser queries with HTTP range requests, plus a drop-in search component shortcode."
+}


### PR DESCRIPTION
Adds [eleventy-plugin-rangefind](https://www.npmjs.com/package/eleventy-plugin-rangefind): serverless full-text search for Eleventy sites.

On `eleventy.after` it indexes the built HTML into a [rangefind](https://rangefind.dev) static index — BM25F relevance, typo correction, search-as-you-type — and registers a `rangefindSearch` shortcode that mounts an accessible web-component search box. The browser queries the index with HTTP range requests: no search server, works on any static host.

Built with Eleventy and dogfooded on https://rangefind.dev (the site's own search runs through this plugin). Tested end-to-end against a real Eleventy build in CI.