### PR TITLE
Add eleventy-plugin-shotpipe to community plugins

### DIFF
--- a/src/_data/plugins/eleventy-plugin-shotpipe.json
+++ b/src/_data/plugins/eleventy-plugin-shotpipe.json
@@ -1,0 +1,5 @@
+{
+	"npm": "eleventy-plugin-shotpipe",
+	"author": "podop29",
+	"description": "Open Graph images with zero build-time cost: og:image URLs are signed locally at build time and rendered on the first crawler hit. No headless browser in your build."
+}


### PR DESCRIPTION
Adds [eleventy-plugin-shotpipe](https://www.npmjs.com/package/eleventy-plugin-shotpipe) to the plugins data.

It generates Open Graph images with zero build-time cost: the plugin signs og:image URLs locally during the build (one HMAC per page, no network calls), and the image renders lazily on the first social-crawler hit. No headless browser or Satori in the build. Repo:
https://github.com/podop29/eleventy-plugin-shotpipe