### PR TITLE
Add eleventy-plugin-deskcrew

### DIFF
--- a/src/_data/plugins/eleventy-plugin-deskcrew.json
+++ b/src/_data/plugins/eleventy-plugin-deskcrew.json
@@ -1,0 +1,5 @@
+{
+	"npm": "eleventy-plugin-deskcrew",
+	"author": "webmilmind1",
+	"description": "Adds the DeskCrew support widget to every page: live chat, AI answers from your knowledge base, and a help center"
+}


### PR DESCRIPTION
Adds a plugin that injects the DeskCrew support widget into every page of an
Eleventy site: live chat, AI answers sourced from the site's own knowledge base,
and a hosted help center. Free plan, no card.

Plugin: https://www.npmjs.com/package/eleventy-plugin-deskcrew
Source: https://github.com/webmilmind1/eleventy-plugin-deskcrew (MIT)
