### PR TITLE
Add eleventy-plugin-mermaid-build to community plugins

### DIFF
--- a/src/_data/plugins/eleventy-plugin-mermaid-build.json
+++ b/src/_data/plugins/eleventy-plugin-mermaid-build.json
@@ -1,0 +1,5 @@
+{
+	"npm": "eleventy-plugin-mermaid-build",
+	"author": "octipus",
+	"description": "renders Mermaid markdown code fences as accessible inline SVG at build time"
+}


### PR DESCRIPTION
## Summary

- Adds `eleventy-plugin-mermaid-build` to the community plugins list
- Renders Mermaid markdown code fences as accessible inline SVG at build time

## Plugin links

- npm: https://www.npmjs.com/package/eleventy-plugin-mermaid-build
- GitHub: https://github.com/octipus/eleventy-plugin-mermaid-build

## Test plan

- [x] JSON file follows the format in `src/_data/plugins/readme.md`
- [x] Package is published on npm


Made with [Cursor](https://cursor.com)