### PR TITLE
Add deploybase to deployment hosts

### DIFF
--- a/src/docs/deployment.md
+++ b/src/docs/deployment.md
@@ -53,6 +53,10 @@ hosts:
     url: https://www.deployhq.com/
     screenshotSize: medium
     description: Git-based deployment platform that runs your Eleventy build on its servers and transfers the <code>_site/</code> output to your own server via SSH/SFTP/FTP (or to S3, Azure Blob, or Rackspace Cloud Files). Supports multiple environments with branch-to-server mapping, config-file injection, atomic releases, one-click rollback, and pre/post deploy hooks.
+  - name: deploybase
+    url: https://deploybase.eu/
+    screenshotSize: medium
+    description: European static site hosting that builds your Eleventy site from a git repo and serves the <code>_site/</code> output from a global CDN. Every branch gets a preview URL, promoting to production is instant (rollback is the same operation), and built-in forms with GDPR retention are included. Runs entirely on EU infrastructure.
 classicHosts:
   - name: Vercel CLI
     url: https://vercel.com/cli


### PR DESCRIPTION
Adds deploybase to the `hosts:` list: European static site hosting that builds Eleventy sites from a git repo and serves the `_site/` output from a global CDN, with a preview URL per branch, instant promote/rollback, and built-in forms.

Setup for Eleventy is a one-line config: build command `npx @11ty/eleventy`, output directory `_site`.

Disclosure: I'm the founder. Happy to trim the description or drop it entirely if you prefer the bare name+url style of most entries.