### PR TITLE
Add harvis to the Classic Web Hosts deployment list

### DIFF
--- a/src/docs/deployment.md
+++ b/src/docs/deployment.md
@@ -79,6 +79,9 @@ classicHosts:
   - name: Orbiter
     url: https://orbiter.host
     screenshotSize: medium
+  - name: harvis
+    url: https://harvis.dev/
+    screenshotSize: medium
 webides:
   - name: Stackblitz
     url: https://stackblitz.com/


### PR DESCRIPTION
Adds [harvis](https://harvis.dev/) to the **Classic Web Hosts** list.

harvis fits the category's "manual static file uploads" definition: run `npx harvis` in any folder (or drag it into the browser) and the files are uploaded as-is and served at a live URL in a couple of seconds — no account, no config, no build step. Running it again updates the same site. Free tier for small sites (1 GB / 100k requests per month), usage-based paid plans above that.

Disclosure: I'm the maintainer of harvis. Entry follows the same three-line format as the other classic hosts.