### PR TITLE
docs: remove duplicated words in RSS plugin and glossary pages

### DIFF
--- a/src/docs/glossary.md
+++ b/src/docs/glossary.md
@@ -105,7 +105,7 @@ To be honest it’s kind of a stretch to relate Lean methodology to this project
 
 Zero config means that Eleventy can run without any command line parameters or configuration files.
 
-We’ve taken care to setup Eleventy so that that running the stock `eleventy` command uses sensible defaults. Lower the barrier to entry for that first project build to get up and running faster.
+We’ve taken care to setup Eleventy so that running the stock `eleventy` command uses sensible defaults. Lower the barrier to entry for that first project build to get up and running faster.
 
 ### Convention over Configuration Routing
 

--- a/src/docs/plugins/rss.md
+++ b/src/docs/plugins/rss.md
@@ -33,7 +33,7 @@ npm install @11ty/eleventy-plugin-rss
 {%- endset %}
 {{ codeBlock | highlight("bash") | safe }}
 
-* `v2` of this this plugin requires Eleventy v3.0 or newer.
+* `v2` of this plugin requires Eleventy v3.0 or newer.
 * `v1` of this plugin is compatible with Eleventy 0.11 or newer.
 
 ## Virtual Template


### PR DESCRIPTION
## Summary

Remove duplicated words in documentation pages.

| File | Fix |
|------|-----|
| src/docs/plugins/rss.md | "this this" → "this" |
| src/docs/glossary.md | "that that" → "that" |

## Test plan

- [x] Verified each typo present before editing
- [x] Residual scan clean on changed files
