### PR TITLE
Add CMS Brew to the CMS list

### DIFF
--- a/src/docs/cms.md
+++ b/src/docs/cms.md
@@ -10,6 +10,9 @@ cmses:
   - name: GitCMS
     url: https://gitcms.blog/
     tags: [Git-based]
+  - name: CMS Brew
+    url: https://cmsbrew.com/?utm_source=11ty-docs
+    tags: [Git-based]
   - name: WordPress REST API
     url: https://developer.wordpress.org/rest-api/
     screenshotSize: medium


### PR DESCRIPTION
Adds CMS Brew to the `cmses` list on the Using a CMS page, tagged Git-based like CloudCannon, GitCMS, Decap, and Pages CMS.

CMS Brew is a hosted Git-based CMS for Eleventy and other static site generators. The client describes a change in chat, the service maps the repository's content, front matter, and data files on connect with no config file, and edits land as ordinary commits on GitHub or GitLab. Risky changes are held for the developer to approve.

Disclosure: I am the maker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)